### PR TITLE
Feature/fix overestimation

### DIFF
--- a/class/NormalGenerativeModel.R
+++ b/class/NormalGenerativeModel.R
@@ -53,7 +53,7 @@ NormalGenerativeModel <- R6Class("NormalGenerativeModel",
       y01 <- 5*z1 + 31
       
       # change in stage1
-      z2 <- private$m.L[2,1] * x[1] + private$m.L[2,2] * x[2]
+      z2 <- private$m.L[1,2] * x[1] + private$m.L[2,2] * x[2]
       switch (group,
         "DD" = y1 <- 7*z2 + (16*private$m.pi + 9.7*(1-private$m.pi) + private$m.delta1),
         "rPD" = y1 <- 2*z2 + 16,
@@ -63,7 +63,7 @@ NormalGenerativeModel <- R6Class("NormalGenerativeModel",
       )
       
       # change in stage2
-      z3 <- private$m.L[3,1] * x[1] + private$m.L[3,2] * x[2] + private$m.L[3,3] * x[3]
+      z3 <- private$m.L[1,3] * x[1] + private$m.L[2,3] * x[2] + private$m.L[3,3] * x[3]
       switch (group,
               "DD" = y2 <- 7*z3 + 0.6*y1,
               "rPD" = y2 <- 2*z3 + (0.6*y1 + private$m.delta2_nr*private$m.h),

--- a/class/NormalGenerativeModel.R
+++ b/class/NormalGenerativeModel.R
@@ -64,12 +64,13 @@ NormalGenerativeModel <- R6Class("NormalGenerativeModel",
       
       # change in stage2
       z3 <- private$m.L[1,3] * x[1] + private$m.L[2,3] * x[2] + private$m.L[3,3] * x[3]
+      # TODO : fix overestimation Corr(Y1, Y2)
       switch (group,
-              "DD" = y2 <- 7*z3 + 0.6*y1,
-              "rPD" = y2 <- 2*z3 + (0.6*y1 + private$m.delta2_nr*private$m.h),
-              "rPP" = y2 <- 2*z3 + 0.6*y1,
-              "nPD" = y2 <- 2*z3 + (0.6*y1 + private$m.delta2_nr),
-              "nPP" = y2 <- 2*z3 + 0.6*y1,
+              "DD" = y2 <- 7*z3 + 0.6*(16*private$m.pi + 9.7*(1-private$m.pi) + private$m.delta1),
+              "rPD" = y2 <- 2*z3 + (0.6*16 + private$m.delta2_nr*private$m.h),
+              "rPP" = y2 <- 2*z3 + 0.6*16,
+              "nPD" = y2 <- 2*z3 + (0.6*9.7 + private$m.delta2_nr),
+              "nPP" = y2 <- 2*z3 + 0.6*9.7,
       )
       
       return (c(y01, y1, y2))


### PR DESCRIPTION
標準正規乱数の線形結合により、任意の相関係数を持つ乱数を生成するが、Stage2において`y1`と`y2`の相関係数が過大評価される。

平均の作り方に問題があるが、相関を落としつつ所望の平均にする方法がわからない。